### PR TITLE
Update webui.py

### DIFF
--- a/webui.py
+++ b/webui.py
@@ -286,6 +286,11 @@ def api_only():
     print(f"Startup time: {startup_timer.summary()}.")
     api.launch(server_name="0.0.0.0" if cmd_opts.listen else "127.0.0.1", port=cmd_opts.port if cmd_opts.port else 7861)
 
+# patch in url for api docs
+def my_setup(self):
+    self.docs_url = "/docs"
+    self.redoc_url = "/redoc"
+    self.orig_setup()
 
 def webui():
     launch_api = cmd_opts.api
@@ -313,6 +318,9 @@ def webui():
                 for line in file.readlines():
                     gradio_auth_creds += [x.strip() for x in line.split(',') if x.strip()]
 
+        if launch_api:
+            FastAPI.orig_setup = FastAPI.setup
+            setattr(FastAPI, "setup", my_setup)            
         app, local_url, share_url = shared.demo.launch(
             share=cmd_opts.share,
             server_name=server_name,


### PR DESCRIPTION
Fix missing /docs endpoint in newer gradio versions 
Newer versions of gradio (>=3.27.0) have removed the /docs endpoint by default. This commit adds it back to enable accessing the API documentation.

This pull request fixes an issue where newer gradio versions (>=3.27.0) no longer expose the /docs endpoint to access the API documentation by default.


To resolve this, I have:
1. Update webui.py

This enables users of the stable-diffusion-webui to access the /docs endpoint again to view the API documentation in newer gradio versions.


**Environment this was tested in**
 - OS: Windows 10
 - Browser: Chrome
 - Graphics card: NVIDIA GTX 3080 10GB


<img width="812" alt="image" src="https://user-images.githubusercontent.com/3376711/236679202-ede93a18-5443-4238-aabd-c4d5b3b13cf9.png">
<img width="710" alt="image" src="https://user-images.githubusercontent.com/3376711/236679216-e2e037ed-e2d9-476d-9a85-951663f0b132.png">

